### PR TITLE
security: remediate idna CVE-2026-45409, release 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to `fabric-comanage-api` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2026-05-28
+
+### Security
+
+- Bumped `idna` to `>=3.15` (resolved to 3.17 in the lock file) to remediate
+  [CVE-2026-45409](https://github.com/advisories) (transitive via `requests`).
+
 ## [0.2.1] - 2026-05-13
 
 ### Security

--- a/comanage_api/__init__.py
+++ b/comanage_api/__init__.py
@@ -16,7 +16,7 @@ from ._orgidentities import OrgIdentitiesMixin
 from ._sshkeys import SshKeysMixin
 
 # fabric-comanage-api version
-__VERSION__ = "0.2.1"
+__VERSION__ = "0.2.2"
 
 # Library logging: NullHandler prevents "last resort" output for callers
 # who don't configure logging. Callers who want logs should add their own

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -52,7 +52,7 @@ class TestConstructor:
         assert isinstance(adapter, HTTPAdapter)
 
     def test_version(self):
-        assert __VERSION__ == '0.2.1'
+        assert __VERSION__ == '0.2.2'
 
 
 class TestOptionSets:

--- a/uv.lock
+++ b/uv.lock
@@ -166,11 +166,11 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "idna"
-version = "3.12"
+version = "3.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/22/12/2948fbe5513d062169bd91f7d7b1cd97bc8894f32946b71fa39f6e63ca0c/idna-3.12.tar.gz", hash = "sha256:724e9952cc9e2bd7550ea784adb098d837ab5267ef67a1ab9cf7846bdbdd8254", size = 194350, upload-time = "2026-04-21T13:32:48.916Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/b2/acc33950394b3becb2b664741a0c0889c7ef9f9ffbfa8d47eddb53a50abd/idna-3.12-py3-none-any.whl", hash = "sha256:60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67", size = 68634, upload-time = "2026-04-21T13:32:47.403Z" },
+    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump `idna` 3.12 → 3.17 in `uv.lock` (transitive via `requests`) to remediate [CVE-2026-45409](https://github.com/fabric-testbed/python-comanage-api/security/dependabot/6) (Moderate, flagged by Dependabot — requires `>= 3.15`).
- Release 0.2.2: version bump in `comanage_api/__init__.py`, `CHANGELOG.md` entry, and version assertion in `tests/test_api.py`.

Lock-file-only dependency change — no minimum Python or direct dependency bump required.

## Test plan
- [x] `uv run pytest -q` — 138 passed
- [x] Confirmed `idna` resolves to 3.17 in `uv.lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)